### PR TITLE
Replaced deprecated method in SnackbarFactory.

### DIFF
--- a/app/src/main/java/com/hitherejoe/pickr/util/SnackbarFactory.java
+++ b/app/src/main/java/com/hitherejoe/pickr/util/SnackbarFactory.java
@@ -2,6 +2,7 @@ package com.hitherejoe.pickr.util;
 
 import android.content.Context;
 import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -12,7 +13,7 @@ public class SnackbarFactory {
     public static Snackbar createSnackbar(Context context, View view, String message) {
         Snackbar snackbar = Snackbar.make(view, message, Snackbar.LENGTH_SHORT);
         ViewGroup group = (ViewGroup) snackbar.getView();
-        group.setBackgroundColor(context.getResources().getColor(R.color.primary));
+        group.setBackgroundColor(ContextCompat.getColor(context, R.color.primary));
         return snackbar;
     }
 }


### PR DESCRIPTION
According to the Android docs, `getColor(int)` was deprecated in API level 23. Their recommendation is to use `getColor(int, Theme)`. However after some Googling, it seems `ContextCompat.getColor(Context, int)` is the preferred alternative.

See these two Stack Overflow: [here](http://stackoverflow.com/questions/31590714/getcolorint-id-deprecated-on-android-6-0-marshmallow-api-23) and [here](http://stackoverflow.com/questions/31842983/getresources-getcolor-is-deprecated)
